### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/MaRy-BiRdY/9d6988de-d646-42f9-9373-00a76fe930f6/8cc82ae9-39c5-4870-b686-07242e517c32/_apis/work/boardbadge/97469352-7cd8-41e7-9646-97ae042d5a2f)](https://dev.azure.com/MaRy-BiRdY/9d6988de-d646-42f9-9373-00a76fe930f6/_boards/board/t/8cc82ae9-39c5-4870-b686-07242e517c32/Microsoft.RequirementCategory)
 # training
 Training repo for personal use


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#10](https://dev.azure.com/MaRy-BiRdY/9d6988de-d646-42f9-9373-00a76fe930f6/_workitems/edit/10). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.